### PR TITLE
Add macro comment for MixScope

### DIFF
--- a/lib/src/helpers/mix_scope.dart
+++ b/lib/src/helpers/mix_scope.dart
@@ -79,6 +79,8 @@ abstract class Model extends Listenable {
   }
 }
 
+/// {@template mix.mixscope}
+///
 /// Provides a [Model] to all descendants of this Widget.
 ///
 /// Descendant Widgets can access the model by using the
@@ -91,13 +93,13 @@ abstract class Model extends Listenable {
 /// ### Example
 ///
 /// ```
-/// ScopedModel<CounterModel>(
-///   model: CounterModel(),
-///   child: ScopedModelDescendant<CounterModel>(
-///     builder: (context, child, model) => Text(model.counter.toString()),
-///   ),
-/// );
+/// MixScope<MixStyles>(
+///   data: MixStyles(),
+///   child: MixDescendantWidget(),
+/// )
 /// ```
+///
+/// {@endtemplate}
 class MixScope<T extends MixData> extends StatelessWidget {
   /// The [Model] to provide to [child] and its descendants.
   final T data;
@@ -105,6 +107,7 @@ class MixScope<T extends MixData> extends StatelessWidget {
   /// The [Widget] the [styles] will be available to.
   final Widget child;
 
+  /// {@macro mix.mixscope}
   const MixScope({
     required this.data,
     required this.child,

--- a/lib/src/helpers/mix_scope.dart
+++ b/lib/src/helpers/mix_scope.dart
@@ -95,7 +95,7 @@ abstract class Model extends Listenable {
 /// ```
 /// MixScope<MixStyles>(
 ///   data: MixStyles(),
-///   child: MixDescendantWidget(),
+///   child: MyApp(),
 /// )
 /// ```
 ///


### PR DESCRIPTION
I have added the **macro comment tag** to the constructor of `MixScope` so that the documentation shows up in the IDE.

Have also updated the **Example** under that to the following:

```dart
MixScope<MixStyles>(
  data: MixStyles(),
  child: MixDescendantWidget(),
)
```

Is `MixDescendantWidget()` alright as the child or should I change it to `MyApp()`. Let me know how you want to keep the example.