### PR TITLE
Pressable Widget

### DIFF
--- a/lib/mix.dart
+++ b/lib/mix.dart
@@ -7,6 +7,7 @@ export 'package:mix/src/widgets/primitives/flex_box.dart'
 export 'package:mix/src/widgets/primitives/icon.dart' show IconMix;
 export 'package:mix/src/widgets/primitives/text.dart'
     show TextMix, TextMixerWidget;
+export 'package:mix/src/widgets/primitives/pressable.dart' show Pressable;
 
 export 'src/attributes/attributes_api.dart';
 export 'src/attributes/base_attribute.dart'

--- a/lib/mix.dart
+++ b/lib/mix.dart
@@ -10,6 +10,7 @@ export 'package:mix/src/widgets/primitives/text.dart'
 export 'package:mix/src/widgets/primitives/pressable.dart' show Pressable;
 
 export 'src/attributes/attributes_api.dart';
+export 'src/attributes/primitives/rendering/flex/main_axis_size.dart';
 export 'src/attributes/base_attribute.dart'
     show Attribute, DynamicAttribute, AttributeExtensions;
 export 'src/helpers/extensions.dart';

--- a/lib/src/attributes/primitives/gestures/disabled.dart
+++ b/lib/src/attributes/primitives/gestures/disabled.dart
@@ -1,0 +1,16 @@
+import '../../../../mix.dart';
+import '../../base_attribute.dart';
+
+class DisabledUtility {
+  const DisabledUtility();
+  DisabledAttribute call(Mix mix) => DisabledAttribute(mix);
+}
+
+class DisabledAttribute extends Attribute<Mix> {
+  const DisabledAttribute(this.mix);
+
+  final Mix mix;
+
+  @override
+  Mix get value => mix;
+}

--- a/lib/src/attributes/primitives/gestures/focused.dart
+++ b/lib/src/attributes/primitives/gestures/focused.dart
@@ -1,0 +1,16 @@
+import '../../../../mix.dart';
+import '../../base_attribute.dart';
+
+class FocusedUtility {
+  const FocusedUtility();
+  FocusedAttribute call(Mix mix) => FocusedAttribute(mix);
+}
+
+class FocusedAttribute extends Attribute<Mix> {
+  const FocusedAttribute(this.mix);
+
+  final Mix mix;
+
+  @override
+  Mix get value => mix;
+}

--- a/lib/src/attributes/primitives/gestures/hovering.dart
+++ b/lib/src/attributes/primitives/gestures/hovering.dart
@@ -1,0 +1,16 @@
+import '../../../../mix.dart';
+import '../../base_attribute.dart';
+
+class HoveringUtility {
+  const HoveringUtility();
+  HoveringAttribute call(Mix mix) => HoveringAttribute(mix);
+}
+
+class HoveringAttribute extends Attribute<Mix> {
+  const HoveringAttribute(this.mix);
+
+  final Mix mix;
+
+  @override
+  Mix get value => mix;
+}

--- a/lib/src/attributes/primitives/gestures/pressing.dart
+++ b/lib/src/attributes/primitives/gestures/pressing.dart
@@ -1,0 +1,16 @@
+import '../../../../mix.dart';
+import '../../base_attribute.dart';
+
+class PressingUtility {
+  const PressingUtility();
+  PressingAttribute call(Mix mix) => PressingAttribute(mix);
+}
+
+class PressingAttribute extends Attribute<Mix> {
+  const PressingAttribute(this.mix);
+
+  final Mix mix;
+
+  @override
+  Mix get value => mix;
+}

--- a/lib/src/mixer/mixer.dart
+++ b/lib/src/mixer/mixer.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:mix/src/attributes/primitives/gestures/disabled.dart';
+import 'package:mix/src/attributes/primitives/gestures/focused.dart';
+import 'package:mix/src/attributes/primitives/gestures/hovering.dart';
+import 'package:mix/src/attributes/primitives/gestures/pressing.dart';
 import 'package:mix/src/attributes/primitives/icon/icon_color.dart';
 import 'package:mix/src/attributes/primitives/layout/aspect_ratio.dart';
 import 'package:mix/src/attributes/primitives/painting/background_color.dart';
@@ -101,6 +105,10 @@ class Mixer {
   IconSizeAttribute? iconSize;
   List<DynamicAttribute>? dynamicAttributes;
   List<TextDirectiveAttribute>? textDirectiveAttributes;
+  DisabledAttribute? disabled;
+  FocusedAttribute? focused;
+  HoveringAttribute? hovering;
+  PressingAttribute? pressing;
 
   /// Applies `DynamicAttribute` based on context
   Mixer applyDynamicAttributes(BuildContext context) {

--- a/lib/src/mixer/mixer.dart
+++ b/lib/src/mixer/mixer.dart
@@ -351,6 +351,23 @@ class Mixer {
       if (attribute is FlexFitAttribute) {
         mixer.flexFit = attribute;
       }
+
+      if (attribute is DisabledAttribute) {
+        mixer.disabled = attribute;
+      }
+
+      if (attribute is FocusedAttribute) {
+        mixer.focused = attribute;
+      }
+
+      if (attribute is HoveringAttribute) {
+        mixer.hovering = attribute;
+        print('haha');
+      }
+
+      if (attribute is PressingAttribute) {
+        mixer.pressing = attribute;
+      }
     }
 
     if (mixer.height != null ||

--- a/lib/src/mixer/mixer.dart
+++ b/lib/src/mixer/mixer.dart
@@ -362,7 +362,6 @@ class Mixer {
 
       if (attribute is HoveringAttribute) {
         mixer.hovering = attribute;
-        print('haha');
       }
 
       if (attribute is PressingAttribute) {

--- a/lib/src/utilities/utilities_api.dart
+++ b/lib/src/utilities/utilities_api.dart
@@ -1,3 +1,4 @@
+import 'package:mix/src/attributes/primitives/gestures/disabled.dart';
 import 'package:mix/src/attributes/primitives/painting/alignment.dart';
 import 'package:mix/src/attributes/primitives/painting/border_radius.dart';
 import 'package:mix/src/utilities/apply_mix.dart';
@@ -56,3 +57,10 @@ const titleCase = TextDirectiveAttribute(TitleCaseDirective());
 const sentenceCase = TextDirectiveAttribute(SentenceCaseDirective());
 
 const apply = ApplyMixUtility();
+
+// Gestures
+
+const disabled = DisabledUtility();
+const focused = DisabledUtility();
+const hovering = DisabledUtility();
+const pressing = DisabledUtility();

--- a/lib/src/utilities/utilities_api.dart
+++ b/lib/src/utilities/utilities_api.dart
@@ -1,4 +1,7 @@
 import 'package:mix/src/attributes/primitives/gestures/disabled.dart';
+import 'package:mix/src/attributes/primitives/gestures/focused.dart';
+import 'package:mix/src/attributes/primitives/gestures/hovering.dart';
+import 'package:mix/src/attributes/primitives/gestures/pressing.dart';
 import 'package:mix/src/attributes/primitives/painting/alignment.dart';
 import 'package:mix/src/attributes/primitives/painting/border_radius.dart';
 import 'package:mix/src/utilities/apply_mix.dart';
@@ -61,6 +64,6 @@ const apply = ApplyMixUtility();
 // Gestures
 
 const disabled = DisabledUtility();
-const focused = DisabledUtility();
-const hovering = DisabledUtility();
-const pressing = DisabledUtility();
+const focused = FocusedUtility();
+const hovering = HoveringUtility();
+const pressing = PressingUtility();

--- a/lib/src/widgets/primitives/pressable.dart
+++ b/lib/src/widgets/primitives/pressable.dart
@@ -5,6 +5,15 @@ import '../../mixer/mixer.dart';
 import '../mix_widget.dart';
 import 'box.dart';
 
+enum _PressableState {
+
+  disabled,
+  focused,
+  hovering,
+  pressing,
+
+}
+
 class Pressable extends MixWidget {
   const Pressable(
     Mix mix, {

--- a/lib/src/widgets/primitives/pressable.dart
+++ b/lib/src/widgets/primitives/pressable.dart
@@ -147,8 +147,6 @@ class _PressableMixerWidgetState extends State<PressableMixerWidget> {
                 if (_shouldShowFocus && focused != null) return focused.mix;
               }();
 
-              print(hovering);
-
               return BoxMixerWidget(
                 widget.mixer,
                 child: () {

--- a/lib/src/widgets/primitives/pressable.dart
+++ b/lib/src/widgets/primitives/pressable.dart
@@ -26,9 +26,8 @@ class Pressable extends MixWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mixer = Mixer.build(context, mix);
     return PressableMixerWidget(
-      mixer,
+      mix,
       onPressed: onPressed,
       onLongPressed: onLongPressed,
       focusNode: focusNode,
@@ -41,7 +40,7 @@ class Pressable extends MixWidget {
 
 class PressableMixerWidget extends StatefulWidget {
   const PressableMixerWidget(
-    this.mixer, {
+    this.mix, {
     required this.child,
     required this.onPressed,
     this.onLongPressed,
@@ -51,7 +50,7 @@ class PressableMixerWidget extends StatefulWidget {
     Key? key,
   }) : super(key: key);
 
-  final Mixer mixer;
+  final Mix mix;
 
   final Widget child;
   final VoidCallback? onPressed;
@@ -135,29 +134,25 @@ class _PressableMixerWidgetState extends State<PressableMixerWidget> {
               if (mounted) setState(() => _pressing = false);
             },
             child: () {
-              final disabled = widget.mixer.disabled;
-              final focused = widget.mixer.focused;
-              final hovering = widget.mixer.hovering;
-              final pressing = widget.mixer.pressing;
+              final mixer = Mixer.build(context, widget.mix);
 
-              Mix? mix = () {
+              final disabled = mixer.disabled;
+              final focused = mixer.focused;
+              final hovering = mixer.hovering;
+              final pressing = mixer.pressing;
+
+              Mix? gestureMix = () {
                 if (!enabled && disabled != null) return disabled.mix;
                 if (_pressing && pressing != null) return pressing.mix;
                 if (_hovering && hovering != null) return hovering.mix;
                 if (_shouldShowFocus && focused != null) return focused.mix;
               }();
 
+              final mixer1 = Mixer.build(context, Mix.combine(widget.mix, gestureMix));
+
               return BoxMixerWidget(
-                widget.mixer,
-                child: () {
-                  if (mix != null) {
-                    return BoxMixerWidget(
-                      Mixer.build(context, mix),
-                      child: widget.child,
-                    );
-                  }
-                  return widget.child;
-                }(),
+                mixer1,
+                child: widget.child,
               );
             }(),
           ),

--- a/lib/src/widgets/primitives/pressable.dart
+++ b/lib/src/widgets/primitives/pressable.dart
@@ -13,7 +13,7 @@ class Pressable extends MixWidget {
     this.onLongPressed,
     this.focusNode,
     this.autofocus = false,
-    this.clipBehavior = Clip.none,
+    this.behavior,
     Key? key,
   }) : super(mix, key: key);
 
@@ -22,7 +22,7 @@ class Pressable extends MixWidget {
   final VoidCallback? onLongPressed;
   final FocusNode? focusNode;
   final bool autofocus;
-  final Clip clipBehavior;
+  final HitTestBehavior? behavior;
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +32,6 @@ class Pressable extends MixWidget {
       onLongPressed: onLongPressed,
       focusNode: focusNode,
       autofocus: autofocus,
-      clipBehavior: clipBehavior,
       child: child,
     );
   }
@@ -46,7 +45,7 @@ class PressableMixerWidget extends StatefulWidget {
     this.onLongPressed,
     this.focusNode,
     this.autofocus = false,
-    this.clipBehavior = Clip.none,
+    this.behavior,
     Key? key,
   }) : super(key: key);
 
@@ -57,7 +56,8 @@ class PressableMixerWidget extends StatefulWidget {
   final VoidCallback? onLongPressed;
   final FocusNode? focusNode;
   final bool autofocus;
-  final Clip clipBehavior;
+
+  final HitTestBehavior? behavior;
 
   @override
   _PressableMixerWidgetState createState() => _PressableMixerWidgetState();
@@ -78,6 +78,12 @@ class _PressableMixerWidgetState extends State<PressableMixerWidget> {
     if (widget.focusNode != oldWidget.focusNode) {
       node = widget.focusNode ?? node;
     }
+  }
+
+  @override
+  void dispose() { 
+    if (widget.focusNode == null) node.dispose();
+    super.dispose();
   }
 
   FocusNode _createFocusNode() {
@@ -109,28 +115,23 @@ class _PressableMixerWidgetState extends State<PressableMixerWidget> {
             if (mounted) setState(() => _hovering = v);
           },
           child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
+            behavior: widget.behavior,
             onTap: widget.onPressed,
             onTapDown: (_) {
               if (mounted) setState(() => _pressing = true);
-              // widget.onTapDown?.call();
             },
             onTapUp: (_) async {
-              // widget.onTapUp?.call();
               if (!enabled) return;
               await Future.delayed(const Duration(milliseconds: 100));
               if (mounted) setState(() => _pressing = false);
             },
             onTapCancel: () {
-              // widget.onTapCancel?.call();
               if (mounted) setState(() => _pressing = false);
             },
             onLongPressStart: (_) {
-              // widget.onLongPressStart?.call();
               if (mounted) setState(() => _pressing = true);
             },
             onLongPressEnd: (_) {
-              // widget.onLongPressEnd?.call();
               if (mounted) setState(() => _pressing = false);
             },
             child: () {


### PR DESCRIPTION
#1

Added `DisabledAttribute`, `FocusedAttribute`, `HoveringAttribute`, `PressingAttribute`.

```dart
Mix(
    apply(_container),
    pressing(Mix(bgColor(RxColors.primary))),
    hovering(Mix(bgColor(RxColors.secondary))),
    apply(RxShadows.shadow20),
)
```

I had to make `PressableMixerWidget` a stateful widget because the current api doesn't offer any type of state management.