### PR TITLE
PressableNotifier

### DIFF
--- a/lib/mix.dart
+++ b/lib/mix.dart
@@ -7,7 +7,7 @@ export 'package:mix/src/widgets/primitives/flex_box.dart'
 export 'package:mix/src/widgets/primitives/icon.dart' show IconMix;
 export 'package:mix/src/widgets/primitives/text.dart'
     show TextMix, TextMixerWidget;
-export 'package:mix/src/widgets/primitives/pressable.dart' show Pressable;
+export 'package:mix/src/widgets/primitives/pressable.dart' show Pressable, PressableNotifier;
 
 export 'src/attributes/attributes_api.dart';
 export 'src/attributes/primitives/rendering/flex/main_axis_size.dart';

--- a/lib/src/mixer/mixer.dart
+++ b/lib/src/mixer/mixer.dart
@@ -126,7 +126,35 @@ class Mixer {
       }
     }
 
-    return Mixer.fromList([...attributes, ...attributesToApply]);
+    return Mixer.fromList([
+      ...attributes,
+      ...attributesToApply,
+    ]);
+  }
+
+  Mixer applyPressableAttributes(BuildContext context) {
+    final pressable = PressableNotifier.of(context);
+
+    if (pressable == null || pressable.isNone) {
+      return this;
+    }
+
+    final pressableAttributesToApply = <Attribute>[];
+
+    if (pressable.disabled && disabled != null) {
+      pressableAttributesToApply.addAll(disabled!.mix.params);
+    } else if (pressable.pressing && pressing != null) {
+      pressableAttributesToApply.addAll(pressing!.mix.params);
+    } else if (pressable.hovering && hovering != null) {
+      pressableAttributesToApply.addAll(hovering!.mix.params);
+    } else if (pressable.focused && focused != null) {
+      pressableAttributesToApply.addAll(focused!.mix.params);
+    }
+
+    return Mixer.fromList([
+      ...attributes,
+      ...pressableAttributesToApply,
+    ]);
   }
 
   /// Applies all [TextModifierAttributes] to [text]
@@ -148,7 +176,9 @@ class Mixer {
 
   factory Mixer.build(BuildContext context, Mix mix) {
     final mixer = Mixer.fromList(mix.params);
-    return mixer.applyDynamicAttributes(context);
+    return mixer
+        .applyDynamicAttributes(context)
+        .applyPressableAttributes(context);
   }
 
   factory Mixer.fromList(List<Attribute> attributes) {

--- a/lib/src/widgets/primitives/icon.dart
+++ b/lib/src/widgets/primitives/icon.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../mix.dart';
 import '../../mixer/mix_factory.dart';
 import '../../mixer/mixer.dart';
 import '../mix_widget.dart';

--- a/lib/src/widgets/primitives/pressable.dart
+++ b/lib/src/widgets/primitives/pressable.dart
@@ -81,7 +81,7 @@ class _PressableMixerWidgetState extends State<PressableMixerWidget> {
   }
 
   @override
-  void dispose() { 
+  void dispose() {
     if (widget.focusNode == null) node.dispose();
     super.dispose();
   }
@@ -149,16 +149,53 @@ class _PressableMixerWidgetState extends State<PressableMixerWidget> {
                 if (_shouldShowFocus && focused != null) return focused.mix;
               }();
 
-              final mixer1 = Mixer.build(context, Mix.combine(widget.mix, gestureMix));
+              final mixer1 =
+                  Mixer.build(context, Mix.combine(widget.mix, gestureMix));
 
-              return BoxMixerWidget(
-                mixer1,
-                child: widget.child,
+              return PressableNotifier(
+                disabled: !enabled,
+                focused: _shouldShowFocus,
+                hovering: _hovering,
+                pressing: _pressing,
+                child: BoxMixerWidget(
+                  mixer1,
+                  child: widget.child,
+                ),
               );
             }(),
           ),
         ),
       ),
     );
+  }
+}
+
+class PressableNotifier extends InheritedWidget {
+  const PressableNotifier({
+    Key? key,
+    required Widget child,
+    this.hovering = false,
+    this.pressing = false,
+    this.focused = false,
+    this.disabled = false,
+  }) : super(key: key, child: child);
+
+  final bool hovering;
+  final bool pressing;
+  final bool focused;
+  final bool disabled;
+
+  bool get isNone => !hovering && !pressing && !focused && !disabled;
+
+  static PressableNotifier? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<PressableNotifier>();
+  }
+
+  @override
+  bool updateShouldNotify(PressableNotifier oldWidget) {
+    return hovering != oldWidget.hovering ||
+        pressing != oldWidget.pressing ||
+        focused != oldWidget.focused ||
+        disabled != oldWidget.disabled;
   }
 }


### PR DESCRIPTION
Currently, when we have a `Pressable` widget, only its own mix is decorated according to its current state (disabled, pressing, hovering or focused).

Now, all the `Mix`es below it can access the current pressable state and change accordingly.

Let's use the following code as example:

```dart
Pressable(
  _outlineMix,
  onPressed: null,
  child: IconMix(
     Mix(
        apply(_icon),
        iconColor(Colors.primary),
        disabled(Mix(iconColor(Colors.grey))),
        hovering(Mix(iconColor(Colors.primary.shade400))),
        pressing(Mix(iconColor(Colors.primary.shade600))),
      ),
     icon: Icons.close,
  ),
),
```

| Previosly | Currently |
| ---------- | ---------- |
| ![old_button](https://user-images.githubusercontent.com/45696119/134026785-eb2e24cf-fcf7-4654-af0e-acbd44ae87bf.png) | ![new_button](https://user-images.githubusercontent.com/45696119/134026833-31754c82-3c70-406f-ab7d-bb990dea9b96.png) |