### PR TITLE
Fix IconMix

### DIFF
--- a/lib/src/widgets/primitives/box.dart
+++ b/lib/src/widgets/primitives/box.dart
@@ -98,7 +98,7 @@ class BoxMixerWidget extends MixerWidget {
 
     final effectivePadding = _paddingIncludingDecoration;
     if (effectivePadding != null) {
-      if (mixer.padding!.hasAnimation) {
+      if (mixer.padding?.hasAnimation ?? false) {
         current = AnimatedPadding(
           duration: mixer.padding!.animationDuration!,
           curve: mixer.padding!.animationCurve!,

--- a/lib/src/widgets/primitives/icon.dart
+++ b/lib/src/widgets/primitives/icon.dart
@@ -46,7 +46,9 @@ class IconMixerWidget extends MixerWidget {
       child: TweenAnimationBuilder<double?>(
         duration: mixer.iconSize?.animationDuration ?? Duration.zero,
         curve: mixer.iconSize?.animationCurve ?? Curves.linear,
-        tween: Tween<double?>(end: mixer.iconSize?.value),
+        tween: Tween<double?>(
+          end: mixer.iconSize?.value ?? IconTheme.of(context).size ?? 24.0,
+        ),
         builder: (context, value, child) {
           return IconTheme.merge(
             data: IconThemeData(size: value),

--- a/test/widgets/box_test.dart
+++ b/test/widgets/box_test.dart
@@ -109,7 +109,7 @@ void main() {
         (tester) async {
           await tester.pumpWidget(
             BoxTestWidget(
-              Mix(const AspectRatioAttribute(3 / 2)),
+              Mix(AspectRatioAttribute(3 / 2)),
             ),
           );
 
@@ -126,7 +126,7 @@ void main() {
         (tester) async {
           await tester.pumpWidget(
             BoxTestWidget(
-              Mix(const AlignmentAttribute(Alignment.centerRight)),
+              Mix(AlignmentAttribute(Alignment.centerRight)),
             ),
           );
 
@@ -143,7 +143,7 @@ void main() {
         (tester) async {
           await tester.pumpWidget(
             BoxTestWidget(
-              Mix(const OpacityAttribute(0.5)),
+              Mix(OpacityAttribute(0.5)),
             ),
           );
 
@@ -160,7 +160,7 @@ void main() {
         (tester) async {
           await tester.pumpWidget(
             BoxTestWidget(
-              Mix(const BackgroundColorAttribute(Colors.lime)),
+              Mix(BackgroundColorAttribute(Colors.lime)),
             ),
           );
 
@@ -175,7 +175,7 @@ void main() {
       testWidgets(
         'Responds to Decoration attributes',
         (tester) async {
-          const side = BorderSideAttribute(
+          final side = BorderSideAttribute(
             color: Colors.green,
             width: 1.0,
             style: BorderStyle.solid,
@@ -184,8 +184,8 @@ void main() {
             BoxTestWidget(
               Mix(
                 BackgroundColorAttribute(Colors.purple),
-                const BorderRadiusAttribute(topLeft: 20),
-                const BorderAttribute(
+                BorderRadiusAttribute(topLeft: 20),
+                BorderAttribute(
                   bottom: side,
                   top: side,
                   left: side,

--- a/test/widgets/icon_test.dart
+++ b/test/widgets/icon_test.dart
@@ -26,8 +26,8 @@ void main() {
       await tester.pumpWidget(
         DirectionalTestWidget(
           child: Mix(
-            const IconColorAttribute(Colors.greenAccent),
-            const IconSizeAttribute(23),
+            IconColorAttribute(Colors.greenAccent),
+            IconSizeAttribute(23),
             const TextDirectionAttribute(TextDirection.rtl),
           ).icon(Icons.bolt),
         ),

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -81,7 +81,7 @@ void main() {
             const LocaleAttribute(Locale('es', 'US')),
             const DebugLabelAttribute('debug_label'),
             const TextHeightAttribute(10),
-            const BackgroundColorAttribute(Colors.blue),
+            BackgroundColorAttribute(Colors.blue),
           ).text(widgetText),
         ),
       );


### PR DESCRIPTION
Currently IconMix throws an error is `iconSize` attribute is not specified.

This also fix the issues on the tests caused by the animation api!