### PR TITLE
Pressable: account for enabled on all pressing toggles

### DIFF
--- a/demo/lib/app_shell.dart
+++ b/demo/lib/app_shell.dart
@@ -43,36 +43,36 @@ class AppShell extends HookConsumerWidget {
         ),
         body: Row(
           children: [
-            // NavigationRail(
-            //   extended: true,
-            //   selectedIndex: selected.value,
-            //   onDestinationSelected: (index) {
-            //     selected.value = index;
-            //   },
-            //   // labelType: NavigationRailLabelType.selected,
-            //   destinations: const <NavigationRailDestination>[
-            //     NavigationRailDestination(
-            //       icon: Icon(Icons.circle),
-            //       label: Text('Basic Example'),
-            //     ),
-            //     NavigationRailDestination(
-            //       icon: Icon(Icons.circle),
-            //       label: Text('Design Tokens'),
-            //     ),
-            //     NavigationRailDestination(
-            //       icon: Icon(Icons.circle),
-            //       label: Text('Pressable'),
-            //     ),
-            //     NavigationRailDestination(
-            //       icon: Icon(Icons.circle),
-            //       label: Text('Cards'),
-            //     ),
-            //     NavigationRailDestination(
-            //       icon: Icon(Icons.circle),
-            //       label: Text('Headless'),
-            //     ),
-            //   ],
-            // ),
+            NavigationRail(
+              extended: true,
+              selectedIndex: selected.value,
+              onDestinationSelected: (index) {
+                selected.value = index;
+              },
+              // labelType: NavigationRailLabelType.selected,
+              destinations: const <NavigationRailDestination>[
+                NavigationRailDestination(
+                  icon: Icon(Icons.circle),
+                  label: Text('Basic Example'),
+                ),
+                NavigationRailDestination(
+                  icon: Icon(Icons.circle),
+                  label: Text('Design Tokens'),
+                ),
+                NavigationRailDestination(
+                  icon: Icon(Icons.circle),
+                  label: Text('Pressable'),
+                ),
+                NavigationRailDestination(
+                  icon: Icon(Icons.circle),
+                  label: Text('Cards'),
+                ),
+                NavigationRailDestination(
+                  icon: Icon(Icons.circle),
+                  label: Text('Headless'),
+                ),
+              ],
+            ),
             const VerticalDivider(thickness: 1, width: 1),
             // This is the main content.
             Expanded(

--- a/demo/lib/views/pressable_preview.dart
+++ b/demo/lib/views/pressable_preview.dart
@@ -3,8 +3,15 @@ import 'package:mix/mix.dart';
 
 import 'button_preview.dart';
 
-class PressablePreview extends StatelessWidget {
+class PressablePreview extends StatefulWidget {
   const PressablePreview({Key? key}) : super(key: key);
+
+  @override
+  State<PressablePreview> createState() => _PressablePreviewState();
+}
+
+class _PressablePreviewState extends State<PressablePreview> {
+  bool _enabled = false;
 
   @override
   Widget build(BuildContext context) {
@@ -37,70 +44,71 @@ class PressablePreview extends StatelessWidget {
       ),
     );
 
-    return SingleChildScrollView(
-      child: Column(
-        children: [
-          Pressable(
-            mix: mix,
-            onPressed: () {
-              showDialog(
-                context: context,
-                builder: (context) {
-                  return AlertDialogX(
-                    content: const [
-                      TextMix('Are you absolutely sure?', variant: title),
-                      TextMix(
-                        'This action cannot be undone. '
-                        'This will permanently delete your account and remove '
-                        'your data from our servers.',
-                        variant: paragraph,
-                      ),
-                    ],
-                    actions: [
-                      button(
-                        child: const TextMix('Cancel'),
-                        onPressed: () {
-                          Navigator.pop(context);
-                        },
-                        overrideMix: Mix(
-                          textColor(Colors.grey.shade700),
-                          bgColor(Colors.grey.shade400),
-                          (hover)(
-                            bgColor(Colors.grey),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SwitchX(
+              active: _enabled,
+              onChanged: (v) => setState(() => _enabled = v),
+            ),
+            const SizedBox(width: 5.0),
+            Text(_enabled ? 'Enabled' : 'Disabled'),
+          ],
+        ),
+        Pressable(
+          mix: mix,
+          onPressed: _enabled
+              ? () {
+                  showDialog(
+                    context: context,
+                    builder: (context) {
+                      return AlertDialogX(
+                        content: const [
+                          TextMix('Are you absolutely sure?', variant: title),
+                          TextMix(
+                            'This action cannot be undone. '
+                            'This will permanently delete your account and remove '
+                            'your data from our servers.',
+                            variant: paragraph,
                           ),
-                        ),
-                      ),
-                      button(
-                        child: const TextMix('Yes, delete account'),
-                        onPressed: () {
-                          Navigator.pop(context);
-                        },
-                        overrideMix: Mix(
-                          textColor(Colors.red.shade100),
-                          bgColor(Colors.redAccent.shade200),
-                          (hover)(
-                            bgColor(Colors.redAccent.shade400),
+                        ],
+                        actions: [
+                          button(
+                            child: const TextMix('Cancel'),
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                            overrideMix: Mix(
+                              textColor(Colors.grey.shade700),
+                              bgColor(Colors.grey.shade400),
+                              (hover)(
+                                bgColor(Colors.grey),
+                              ),
+                            ),
                           ),
-                        ),
-                      ),
-                    ],
+                          button(
+                            child: const TextMix('Yes, delete account'),
+                            onPressed: Navigator.of(context).pop,
+                            overrideMix: Mix(
+                              textColor(Colors.red.shade100),
+                              bgColor(Colors.redAccent.shade200),
+                              (hover)(
+                                bgColor(Colors.redAccent.shade400),
+                              ),
+                            ),
+                          ),
+                        ],
+                      );
+                    },
                   );
-                },
-              );
-            },
-            child: const TextMix(
-              'Simple Text',
-            ),
-          ),
-          Container(
-            decoration: const BoxDecoration(
-              borderRadius: BorderRadius.all(
-                Radius.circular(10),
-              ),
-            ),
-          ),
-        ],
-      ),
+                }
+              : null,
+          child: const TextMix('Simple Text'),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/widgets/pressable.widget.dart
+++ b/lib/src/widgets/pressable.widget.dart
@@ -134,6 +134,7 @@ class _PressableMixerWidgetState extends State<PressableMixerWidget> {
             behavior: widget.behavior,
             onTap: widget.onPressed,
             onTapDown: (_) {
+              if (!enabled) return;
               if (mounted) setState(() => _pressing = true);
             },
             onTapUp: (_) async {
@@ -142,12 +143,15 @@ class _PressableMixerWidgetState extends State<PressableMixerWidget> {
               if (mounted) setState(() => _pressing = false);
             },
             onTapCancel: () {
+              if (!enabled) return;
               if (mounted) setState(() => _pressing = false);
             },
             onLongPressStart: (_) {
+              if (!enabled) return;
               if (mounted) setState(() => _pressing = true);
             },
             onLongPressEnd: (_) {
+              if (!enabled) return;
               if (mounted) setState(() => _pressing = false);
             },
             child: () {


### PR DESCRIPTION
Fixes #59 

The `press` state was still being turned on while disabled. This pr verifies if it's enabled before setting the pressing state to true