### PR TITLE
Turn Variant const again

### DIFF
--- a/lib/src/attributes/variants/variants.utils.dart
+++ b/lib/src/attributes/variants/variants.utils.dart
@@ -136,6 +136,6 @@ class VariantUtils {
   }
 
   static Variant<T> not<T extends Attribute>(Variant<T> other) {
-    return other..inverse = true;
+    return other.inverseInstance();
   }
 }

--- a/lib/src/variants/variants.dart
+++ b/lib/src/variants/variants.dart
@@ -152,9 +152,10 @@ class Variant<T extends Attribute> {
   final String name;
   final bool Function(BuildContext)? shouldApply;
 
-  bool inverse = false;
+  final bool inverse;
 
-  Variant(this.name, {this.shouldApply});
+  const Variant(this.name, {this.shouldApply}) : inverse = false;
+  const Variant._inverse(this.name, {this.shouldApply}) : inverse = true;
 
   MultiVariant<T> operator &(Variant<T> variant) =>
       MultiVariant<T>([this, variant], operator: _VariantOperations.and);
@@ -212,4 +213,11 @@ class Variant<T extends Attribute> {
 
   @override
   String toString() => 'Variant(name: $name)';
+
+  Variant<T> inverseInstance() {
+    return Variant<T>._inverse(
+      name,
+      shouldApply: shouldApply,
+    );
+  }
 }


### PR DESCRIPTION
When the new version of Mix was released, it came with break changes, one of them is the class `Variant` hasn't a constant constructor anymore, what don't allow to use the new format of enums with properties.

In this PR I fix this and `Variant` constructor become constant again.

Changing this:
```dart
enum SomaButtonAppearance {
  primary(Variant("primary")),
  secondary(Variant("secondary")),
  ghost(Variant("ghost"));

  const SomaButtonSize(this.variant);

  final Variant variant;
}
```

To
```dart
enum SomaButtonAppearance{
  primary,
  secondary,
  ghost;

  Variant get variant {
    switch (this) {
      case primary:
        return Variant("primary");
      case secondary:
        return Variant("secondary");
      case ghost:
        return Variant("ghost");
    }
  }
}
```